### PR TITLE
Update against the latest version of the Python API

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,10 @@ notification = None
 config = ConfigFile('~/.binjatron.conf', defaults=PackageFile('defaults.yaml'), apply_env=True, env_prefix='BTRON')
 config.load()
 
+bp_colour = enums.HighlightStandardColor(config.bp_colour)
+pc_colour = enums.HighlightStandardColor(config.pc_colour)
+no_colour = enums.HighlightStandardColor(0)
+
 
 def sync(view):
     global syncing, vers, notification
@@ -54,15 +58,15 @@ def sync(view):
 
                     # add colours to all the breakpoints currently set in the debugger
                     for addr in addrs:
-                        func = view.get_function_at(view.platform, view.get_previous_function_start_before(addr))
+                        func = view.get_function_at(view.get_previous_function_start_before(addr))
                         if func:
-                            func.set_user_instr_highlight(func.arch, addr, config.bp_colour)
+                            func.set_auto_instr_highlight(addr, bp_colour)
 
                     # remove colours from any addresses that had breakpoints the last time we updated, but don't now
                     for addr in set(last_bp_addrs) - set(addrs):
-                        func = view.get_function_at(view.platform, view.get_previous_function_start_before(addr))
+                        func = view.get_function_at(view.get_previous_function_start_before(addr))
                         if func:
-                            func.set_user_instr_highlight(func.arch, addr, 0)
+                            func.set_auto_instr_highlight(addr, no_colour)
 
                     # save this set of breakpoint addresses for next time
                     last_bp_addrs = addrs
@@ -72,17 +76,18 @@ def sync(view):
                     addr = results[0].registers.values()[0] - slide
 
                     # find the function where that address is
-                    func = view.get_function_at(view.platform, view.get_previous_function_start_before(addr))
+                    func = view.get_function_at(view.get_previous_function_start_before(addr))
 
-                    # update the highlight colour of the previous PC to its saved value
-                    func.set_user_instr_highlight(func.arch, last_pc_addr, last_pc_addr_colour)
+                    if last_pc_addr:
+                        # update the highlight colour of the previous PC to its saved value
+                        func.set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
 
                     # save the PC and current colour for that instruction
-                    last_pc_addr_colour = func.get_instr_highlight(func.arch, addr).color
+                    last_pc_addr_colour = func.get_instr_highlight(addr)
                     last_pc_addr = addr
 
                     # update the highlight colour to show the current PC
-                    func.set_user_instr_highlight(func.arch, addr, config.pc_colour)
+                    func.set_auto_instr_highlight(addr, pc_colour)
 
     if not syncing:
         try:
@@ -109,11 +114,13 @@ def stop(view):
         log_info("Stopping synchronisation with Voltron")
 
         # clear any colours we've set
-        func = view.get_function_at(view.platform, view.get_previous_function_start_before(last_pc_addr))
-        func.set_user_instr_highlight(func.arch, last_pc_addr, last_pc_addr_colour)
+        if last_pc_addr:
+            func = view.get_function_at(view.get_previous_function_start_before(last_pc_addr))
+            func.set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
+
         for addr in last_bp_addrs:
-            func = view.get_function_at(view.platform, view.get_previous_function_start_before(addr))
-            func.set_user_instr_highlight(func.arch, addr, 0)
+            func = view.get_function_at(view.get_previous_function_start_before(addr))
+            func.set_auto_instr_highlight(addr, no_colour)
 
         # stop the voltron client
         client.stop()
@@ -153,9 +160,9 @@ def set_breakpoint(view, address):
         res = client.perform_request("command", command="voltron update", block=False)
 
         # add colour in binja
-        func = view.get_function_at(view.platform, view.get_previous_function_start_before(address))
+        func = view.get_function_at(view.get_previous_function_start_before(address))
         if func:
-            func.set_user_instr_highlight(func.arch, address, config.bp_colour)
+            func.set_auto_instr_highlight(address, bp_colour)
     except:
         log_alert("Failed to set breakpoint")
 
@@ -194,9 +201,9 @@ def delete_breakpoint(view, address):
         res = client.perform_request("command", command="voltron update", block=False)
 
         # remove the breakpoint colour in binja
-        func = view.get_function_at(view.platform, view.get_previous_function_start_before(address))
+        func = view.get_function_at(view.get_previous_function_start_before(address))
         if func:
-            func.set_user_instr_highlight(func.arch, address, 0)
+            func.set_auto_instr_highlight(address, no_colour)
     except:
         log_alert("Failed to delete breakpoint")
 


### PR DESCRIPTION
This should make it possible to use the plugin under the latest version of Binary Ninja.

I've also changed `func.set_user_instr_highlight` to `func.set_auto_instr_highlight` so that breakpoint/PC highlights won't be saved to the database.