### PR TITLE
Fix highlighting issues

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -85,7 +85,7 @@ def sync(view):
 
                     if last_pc_addr:
                         # update the highlight colour of the previous PC to its saved value
-                        func.set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
+                        _get_function(view, last_pc_addr).set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
 
                     # save the PC and current colour for that instruction
                     last_pc_addr_colour = func.get_instr_highlight(addr)


### PR DESCRIPTION
3839c6d fixes #1, which arose from `get_previous_function_start` returning the previous function when called on a function entrypoint.

fca7e29 fixes an untracked issue where program counter highlights would not be cleared when `last_pc_addr` was in a different function than the one currently executing (such as immediately after a call instruction)