### PR TITLE
Extensibility functions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -112,6 +112,7 @@ def sync(view):
             vers = client.perform_request("version")
             client.start(build_requests=build_requests, callback=callback)
             syncing = True
+            # Return the sync state so that external code can determine whether voltron is currently syncing with binjatron
             return syncing
         except:
             log_info("Couldn't connect to Voltron")
@@ -248,6 +249,11 @@ def clear_slide(view):
     slide = 0
 
 def custom_request(request, args, alert=True):
+    """ Allows external code to pass arbitrary commands to the voltron client
+    request: type of request - usually 'command'
+    args: dict containing keyword arguments for the request
+    alert: boolean indicating whether errors should result in a popup or simply
+        log to the console. Defaults to True."""
     global vers
     client_result = None
     try:
@@ -272,9 +278,15 @@ def custom_request(request, args, alert=True):
         else:
             log_info(request + " failed: " + str(args))
 
+    # Even if we encountered an exception, we return the results so external code can
+    # handle the error if necessary.
     return client_result
 
 def register_sync_callback(cb, should_delete=False):
+    """ Allows external code to register a callback to be run upon a succesful sync
+    cb: function pointer to the callback. Gets `results` as an argument
+    should_delete: boolean indicating whether the callback should be removed from
+        the list after a single call. Defaults to False. """
     global sync_callbacks
     sync_callbacks.append((cb, should_delete))
 

--- a/__init__.py
+++ b/__init__.py
@@ -61,6 +61,7 @@ def sync(view):
             if mute_errors_after > 0:
                 log_error("Error synchronising: {}".format(error))
             elif mute_errors_after == 0:
+                # Prevent errors from filling up the entire log if the debugger closes and we lose sync
                 log_alert("Voltron encountered three sync errors in a row. Muting errors until the next succesful sync.")
                 syncing = False
             mute_errors_after -= 1
@@ -89,6 +90,7 @@ def sync(view):
                     last_bp_addrs = addrs
 
                 elif last_bp_addrs:
+                    # We end up here if the debugger has been closed and re-opened
                     replace_breakpoints = show_message_box(
                         'New Session',
                         'The Voltron instance currently syncing reports no breakpoints set, but breakpoints have been set in Binary Ninja. Restore these breakpoints?',
@@ -122,6 +124,7 @@ def sync(view):
                     # update the highlight colour to show the current PC
                     func.set_auto_instr_highlight(addr, pc_colour)
 
+                    # Run sync callbacks and remove them from the list if specified
                     for cb, _ in sync_callbacks:
                         cb(results)
                     sync_callbacks = filter(lambda cbt: not cbt[1], sync_callbacks)

--- a/__init__.py
+++ b/__init__.py
@@ -214,7 +214,7 @@ def set_breakpoint(view, address):
 
 
 def delete_breakpoint(view, address):
-    global vers
+    global vers, last_bp_addrs
 
     try:
         if not vers:
@@ -250,6 +250,7 @@ def delete_breakpoint(view, address):
         func = _get_function(view, address)
         if func:
             func.set_auto_instr_highlight(address, no_colour)
+        last_bp_addrs = filter(lambda k : k != address, last_bp_addrs)
     except:
         log_alert("Failed to delete breakpoint")
 

--- a/__init__.py
+++ b/__init__.py
@@ -90,21 +90,22 @@ def sync(view):
                     last_bp_addrs = addrs
 
                 elif last_bp_addrs:
-                    # We end up here if the debugger has been closed and re-opened
-                    replace_breakpoints = show_message_box(
-                        'New Session',
-                        'The Voltron instance currently syncing reports no breakpoints set, but breakpoints have been set in Binary Ninja. Restore these breakpoints?',
-                        buttons=enums.MessageBoxButtonSet.YesNoButtonSet)
+                    if (results[1].status == 'success') or (hasattr(results[1], 'message') and 'busy' not in results[1].message.lower()):
+                        # We end up here if the debugger has been closed and re-opened
+                        replace_breakpoints = show_message_box(
+                            'New Session',
+                            'The Voltron instance currently syncing reports no breakpoints set, but breakpoints have been set in Binary Ninja. Restore these breakpoints?',
+                            buttons=enums.MessageBoxButtonSet.YesNoButtonSet)
 
-                    if replace_breakpoints:
-                        for addr in set(last_bp_addrs):
-                            set_breakpoint(view, addr)
-                    else:
-                        for addr in set(last_bp_addrs):
-                            func = _get_function(view, addr)
-                            if func:
-                                func.set_auto_instr_highlight(addr, no_colour)
-                        last_bp_addrs = []
+                        if replace_breakpoints:
+                            for addr in set(last_bp_addrs):
+                                set_breakpoint(view, addr)
+                        else:
+                            for addr in set(last_bp_addrs):
+                                func = _get_function(view, addr)
+                                if func:
+                                    func.set_auto_instr_highlight(addr, no_colour)
+                            last_bp_addrs = []
 
                 if results[0].registers:
                     # get the current PC from the debugger
@@ -133,9 +134,6 @@ def sync(view):
                     if last_pc_addr:
                         # update the highlight colour of the previous PC to its saved value
                         _get_function(view, last_pc_addr).set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
-
-
-
 
     if not syncing:
         try:

--- a/__init__.py
+++ b/__init__.py
@@ -107,6 +107,26 @@ def sync(view):
                     for cb, _ in sync_callbacks:
                         cb(results)
                     sync_callbacks = filter(lambda cbt: not cbt[1], sync_callbacks)
+                if not results[0].registers and not results[1].breakpoints:
+                    if last_pc_addr:
+                        # update the highlight colour of the previous PC to its saved value
+                        _get_function(view, last_pc_addr).set_auto_instr_highlight(last_pc_addr, last_pc_addr_colour)
+
+                    replace_breakpoints = show_message_box(
+                        'New Session',
+                        'The Voltron instance currently syncing reports no breakpoints set, but breakpoints have been set in Binary Ninja. Restore these breakpoints?',
+                        buttons=enums.MessageBoxButtonSet.YesNoButtonSet)
+
+                    if replace_breakpoints:
+                        for addr in set(last_bp_addrs):
+                            set_breakpoint(view, addr)
+                    else:
+                        for addr in set(last_bp_addrs):
+                            func = _get_function(view, addr)
+                            if func:
+                                func.set_auto_instr_highlight(addr, no_colour)
+
+
 
     if not syncing:
         try:


### PR DESCRIPTION
This PR adds several features that make it easier to write plugins for Binary Ninja that take advantage of features provided by voltron. It also alters the way Binjatron handles sync issues so that it is easier to close the debugger and open a new one without having to stop Voltron from syncing.

 - ccee75e adds a custom request function that allows external code to pass commands to the voltron client and get the results.
 - 49c8927 adds a simple callback system that allows external code to register a callback to be executed upon the next successful sync with Voltron. 
 -  eb0253c adds a simple wrapper function to get the current sync state and implements an error mute countdown so that if multiple sync errors are received in sequence, errors will be muted until successful sync is restored.
 - f2349f6 and e4c559b improve the behavior of highlighting when the inferior process is killed by the debugger, or the debugger is closed and sync with Voltron is disrupted. If the debugger reports no breakpoints set, but breakpoints have been set within Binary Ninja during the session, the user will be prompted to either discard or restore these breakpoints.